### PR TITLE
fix: 워크스페이스 입장 직후 userStore에 프로필 정보 반영되도록 수정

### DIFF
--- a/src/pages/workspacePage/WorkspacePage.tsx
+++ b/src/pages/workspacePage/WorkspacePage.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { fetchMyWorkspaces } from '@/api/Workspace';
 import { getMyProfile } from '@/api/Member';
 import { useWorkspaceStore } from '@/stores/workspaceStore';
+import { useUserStore } from '@/stores/userStore';
 import DropdownIcon from '@/assets/icons/DropdownIcon.svg?url';
 
 export const WorkspacePage = () => {
@@ -83,6 +84,10 @@ export const WorkspacePage = () => {
       });
 
       const profileData = await getMyProfile();
+      useUserStore.getState().setProfileInfo({
+        name: profileData.realName ?? '',
+        profileFileUrl: profileData.profileFileUrl ?? '',
+      });
       // console.log('내 프로필 데이터:', profileData);
       // useWorkspaceStore.getState().setMyProfileFor(selectedId, profileData);
       navigate(`/${selectedSlug}/project`);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

연관된 이슈 번호를 작성해주세요.

## 💯 PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 변경 사항 요약
- 워크스페이스 입장 직후 NavProfile에 사용자 프로필 이미지가 뜨지 않는 문제 수정
- WorkspacePage에서 getMyProfile() 호출 후, userStore.setProfileInfo()를 호출하여 전역 사용자 정보 동기화
- 프로필 설정 페이지(ProfilePage)를 거치지 않아도 바로 프로필 이미지가 보이도록 개선

## 📷 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
